### PR TITLE
Add support for scoll keybinds

### DIFF
--- a/src/input/key_map/mod.rs
+++ b/src/input/key_map/mod.rs
@@ -193,23 +193,25 @@ fn parse_key(data: &str) -> Result<Key> {
     } else {
         // No modifier; just get the key.
         Ok(match component {
-            "space"     => Key::Char(' '),
-            "backspace" => Key::Backspace,
-            "left"      => Key::Left,
-            "right"     => Key::Right,
-            "up"        => Key::Up,
-            "down"      => Key::Down,
-            "home"      => Key::Home,
-            "end"       => Key::End,
-            "page_up"   => Key::PageUp,
-            "page_down" => Key::PageDown,
-            "delete"    => Key::Delete,
-            "insert"    => Key::Insert,
-            "escape"    => Key::Esc,
-            "tab"       => Key::Tab,
-            "enter"     => Key::Enter,
-            "_"         => Key::AnyChar,
-            _           => Key::Char(
+            "space"         => Key::Char(' '),
+            "backspace"     => Key::Backspace,
+            "left"          => Key::Left,
+            "right"         => Key::Right,
+            "up"            => Key::Up,
+            "down"          => Key::Down,
+            "home"          => Key::Home,
+            "end"           => Key::End,
+            "page_up"       => Key::PageUp,
+            "page_down"     => Key::PageDown,
+            "delete"        => Key::Delete,
+            "insert"        => Key::Insert,
+            "escape"        => Key::Esc,
+            "tab"           => Key::Tab,
+            "enter"         => Key::Enter,
+            "scroll_up"     => Key::ScrollUp,
+            "scroll_down"   => Key::ScrollDown,
+            "_"             => Key::AnyChar,
+            _               => Key::Char(
                 // It's not a keyword; take its first character, if available.
                 component.chars().nth(0).ok_or_else(||
                     format!("Keymap key \"{}\" is invalid", component)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,6 +4,7 @@ mod key_map;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Key {
+    // Keyboard:
     Backspace,
     Left,
     Right,
@@ -21,4 +22,7 @@ pub enum Key {
     AnyChar,
     Char(char),
     Ctrl(char),
+    // Mouse:
+    ScrollUp,
+    ScrollDown,
 }


### PR DESCRIPTION
These can be used as alternatives for pageup/down like so:
```
scroll_up: view::scroll_up
scroll_down: view::scroll_down
```
Or can be used like in some other console based editors to skip a couple of lines like so:
```
scroll_up:
  - cursor::move_up
  - cursor::move_up
  - cursor::move_up
scroll_down:
  - cursor::move_down
  - cursor::move_down
  - cursor::move_down
```